### PR TITLE
Fix linux os detection

### DIFF
--- a/copysysbin.sh
+++ b/copysysbin.sh
@@ -1,4 +1,4 @@
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
+if [[ $OSTYPE == linux-gnu* ]]; then
 	arch=$(uname -m)
 	if [[ "$arch" == "aarch64" ]]; then
 		cp "$( dirname "${BASH_SOURCE[0]}" )"/node-linuxaarch64 "$( dirname "${BASH_SOURCE[0]}" )"/node


### PR DESCRIPTION
On certain arm distributions, the `$OSTYPE` env var can result in something other than `linux-gnu`, this fixes this by using a glob pattern to take into account everything starting with `linux-gnu`